### PR TITLE
Exclude emails without RawData

### DIFF
--- a/app.js
+++ b/app.js
@@ -95,7 +95,7 @@ app.use((err, _req, res, _next) => {
 async function fetchMessages() {
   const response = await fetch(apiUrl);
   const data = await response.json();
-  return data["messages"];
+  return data["messages"].filter(x => x.RawData);
 }
 
 function parseExtraColumns() {

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -21,6 +21,11 @@ describe("App Tests", () => {
             Timestamp: Date.now(),
             RawData: generateMockEml(),
           },
+          {
+            Timestamp: Date.now(),
+            Subject: "Test email",
+            RawData: null,
+          },
         ],
       });
   });


### PR DESCRIPTION
<!-- You MUST update the content to describe what was done -->

## Overview

<!-- Please describe what your pull request does and which issue you’re targeting -->
If you follow https://docs.localstack.cloud/user-guide/aws/ses/, you'll end up with emails that do not contain raw data, which will cause the viewer to crash.
In this PR, I'm excluding those emails from the viewer.


## Notes

<!-- Please add a note in case of something special or new happens in this pull request -->

<!-- Please add references related to this pull request -->
I also plan to include in the viewer the emails without raw data. But for now, I want to make this simple improvement.

