### PR TITLE
Support emails without raw data

### DIFF
--- a/app.js
+++ b/app.js
@@ -19,7 +19,7 @@ app.get("/", async (_req, res, next) => {
         let email = await createEmail(message, index);
         const logos = extraColumns.map(
           (column) =>
-            parsed.attachments.find(
+            email.attachments.find(
               (attachment) => attachment.filename === column.value,
             )?.content,
         );
@@ -108,17 +108,19 @@ async function createEmail(message) {
       subject: parsed.subject,
       to: parsed.to.text,
       html: parsed.html,
+      attachments: parsed.attachments,
       isDownloadable: true,
     };
-  } else {
-    return {
-      timestamp: message.Timestamp,
-      subject: message.Subject,
-      to: message.Destination.ToAddresses,
-      html: message.Body.html_part ?? message.Body.text_part,
-      isDownloadable: false,
-    };
   }
+
+  return {
+    timestamp: message.Timestamp,
+    subject: message.Subject,
+    to: message.Destination.ToAddresses,
+    html: message.Body.html_part ?? message.Body.text_part,
+    attachments: [],
+    isDownloadable: false,
+  };
 }
 
 function parseExtraColumns() {

--- a/app.js
+++ b/app.js
@@ -16,7 +16,7 @@ app.get("/", async (_req, res, next) => {
     const extraColumns = parseExtraColumns() || [];
     const messagesForTemplate = await Promise.all(
       messages.map(async (message, index) => {
-        let result = await createEmail(message, index);
+        let email = await createEmail(message, index);
         const logos = extraColumns.map(
           (column) =>
             parsed.attachments.find(
@@ -24,9 +24,9 @@ app.get("/", async (_req, res, next) => {
             )?.content,
         );
 
-        result.id = index;
-        result.logos = logos;
-        return result;
+        email.id = index;
+        email.logos = logos;
+        return email;
       }),
     );
     res.render("index", {

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -21,6 +21,24 @@ describe("App Tests", () => {
             Timestamp: Date.now(),
             RawData: generateMockEml(),
           },
+          {
+            Timestamp: Date.now(),
+            Subject: "Test email",
+            ToAddresses: ["jeff@aws.com", "adam@aws.com"],
+            Body: {
+              text_part: null,
+              html_part: "<html>This is a test email with html</html>"
+            },
+          },
+          {
+            Timestamp: Date.now(),
+            Subject: "Test email",
+            ToAddresses: ["jeff@aws.com"],
+            Body: {
+              text_part: "This is a test email",
+              html_part: null,
+            },
+          },
         ],
       });
   });

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -24,16 +24,20 @@ describe("App Tests", () => {
           {
             Timestamp: Date.now(),
             Subject: "Test email",
-            ToAddresses: ["jeff@aws.com", "adam@aws.com"],
+            Destination: {
+              ToAddresses: ["jeff@aws.com", "adam@aws.com"]
+            },
             Body: {
               text_part: null,
-              html_part: "<html>This is a test email with html</html>"
+              html_part: "<html>This is a test email with html</html>",
             },
           },
           {
             Timestamp: Date.now(),
             Subject: "Test email",
-            ToAddresses: ["jeff@aws.com"],
+            Destination: {
+              ToAddresses: ["jeff@aws.com"]
+            },
             Body: {
               text_part: "This is a test email",
               html_part: null,
@@ -88,5 +92,10 @@ describe("App Tests", () => {
     expect(response.header["content-disposition"]).toBe(
       'attachment; filename="Test Email.eml"',
     );
+  });
+
+  test("GET /emails/:id/download should return status 400 when the email does not contain raw data", async () => {
+    const response = await supertest(app).get("/emails/2/download");
+    expect(response.status).toBe(400);
   });
 });

--- a/views/index.pug
+++ b/views/index.pug
@@ -65,5 +65,6 @@ html
             td= message.subject
             td
               a(href='/emails/' + message.id) View
-            td
-              a(href='/emails/' + message.id + '/download') Download
+            if message.isDownloadable
+              td
+                a(href='/emails/' + message.id + '/download') Download


### PR DESCRIPTION
<!-- You MUST update the content to describe what was done -->

## Overview

<!-- Please describe what your pull request does and which issue you’re targeting -->
If you follow https://docs.localstack.cloud/user-guide/aws/ses/, you'll end up with emails that do not contain raw data, which will cause the viewer to crash. Therefore, I added support for emails without raw data.

![image](https://github.com/veertech/localstack-aws-ses-email-viewer/assets/8866496/eb81f4ee-2e6b-435d-92ce-f16daa55d266)

- [x] this is done
- [ ] this is in progress

## Notes

<!-- Please add a note in case of something special or new happens in this pull request -->
I decided not to enable the download of emails without raw data, as that wouldn't bring any value.

<!-- Please add references related to this pull request -->

Refs: LM-zxy
