### PR TITLE
Add a delete email option when listing emails

### DIFF
--- a/app.js
+++ b/app.js
@@ -108,6 +108,27 @@ app.get("/emails/:id/download", async (req, res, next) => {
   }
 });
 
+app.get("/emails/:id/delete", async (req, res, next) => {
+  try {
+    const messageId = req.params.id; // The ID from the URL path
+
+    // Send a DELETE request to the API URL with the msg SES ID as a query parameter
+    const response = await fetch(`${apiUrl}?id=${messageId}`, {
+      method: 'DELETE',
+    });
+
+    // Log the response status and body for debugging
+    const responseBody = await response.text();
+    if (response.ok) {
+      // If the deletion is successful, redirect back to the "/"
+      res.redirect('/');
+    } else {
+      res.status(response.status).send(`Failed to delete email: ${responseBody}`);    }
+  } catch (err) {
+    next(err);
+  }
+});
+
 app.use((err, _req, res, _next) => {
   console.error(err.stack);
   res.status(500).send("Something broke!");
@@ -131,6 +152,7 @@ async function createEmail(message) {
       html: parsed.html,
       attachments: parsed.attachments,
       isDownloadable: true,
+      sesid: message.Id,
     };
   }
 
@@ -143,6 +165,7 @@ async function createEmail(message) {
     html: message.Body.html_part ?? message.Body.text_part,
     attachments: [],
     isDownloadable: false,
+    sesid: message.Id,
   };
 }
 

--- a/views/index.pug
+++ b/views/index.pug
@@ -69,6 +69,8 @@ html
             td= message.subject
             td
               a(href='/emails/' + message.id) View
+            td
+              a(href='/emails/' + message.sesid+'/delete') Delete
             if message.isDownloadable
               td
                 a(href='/emails/' + message.id + '/download') Download


### PR DESCRIPTION
<!-- You MUST update the content to describe what was done -->

## Overview

<!-- Please describe what your pull request does and which issue you’re targeting -->

- [x] Adds a delete email option

Adds a delete link to each email in the list on the root (/) page. Pressing delete will send a DELETE request to the localstack endpoint with the message ID attached. 

## Notes

<!-- Please add a note in case of something special or new happens in this pull request -->

<!-- Please add references related to this pull request -->

Also adds the SES message ID into the message  obj so that it can then be deleted on request.

Screenshot of change: 

<img width="812" alt="Screenshot 2025-02-10 at 13 27 47" src="https://github.com/user-attachments/assets/595c3050-ffcd-4779-9930-b042c666a4f7" />


